### PR TITLE
Update Swashbuckle.AspNetCore Version

### DIFF
--- a/src/content/template-layer-compose/Template9/Template9.csproj
+++ b/src/content/template-layer-compose/Template9/Template9.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.10" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Both the application layers and the compose post-build event expect Swashbuckle.AspNetCore 6.9.0 or higher, but the compose layer was referencing an older version (6.6.2). 